### PR TITLE
fix(cli): align ArchiveCommand with Spectre.Console.Cli command registration

### DIFF
--- a/src/Blobify.Tests/Fixture/BlobifyServiceProviderFixture.cs
+++ b/src/Blobify.Tests/Fixture/BlobifyServiceProviderFixture.cs
@@ -6,6 +6,7 @@ using Blobify.Commands;
 using Blobify.Commands.Settings;
 using Devlead.Testing.MockHttp;
 using Blobify.Tests;
+using Spectre.Console.Cli;
 
 public static partial class ServiceProviderFixture
 {
@@ -18,7 +19,7 @@ public static partial class ServiceProviderFixture
                 (_, _) => Task.FromResult(new AccessToken(nameof(AccessToken), DateTimeOffset.UtcNow.AddDays(1)))
             )
             .AddSingleton<TokenService>()
-            .AddSingleton<ArchiveCommand>()
+            .AddSingleton<ICommand<ArchiveSettings>, ArchiveCommand>()
             .AddTransient(
                 _ => new ArchiveSettings
                 {

--- a/src/Blobify.Tests/Unit/Commands/ArchiveCommandTests.cs
+++ b/src/Blobify.Tests/Unit/Commands/ArchiveCommandTests.cs
@@ -1,5 +1,6 @@
 ﻿using Blobify.Commands;
 using Blobify.Commands.Settings;
+using Spectre.Console.Cli;
 
 namespace Blobify.Tests.Unit.Commands;
 public class ArchiveCommandTests
@@ -10,7 +11,7 @@ public class ArchiveCommandTests
         public async Task ExecuteAsync()
         {
             // Given
-            var (archiveCommand, settings) = ServiceProviderFixture.GetRequiredService<ArchiveCommand, ArchiveSettings>();
+            var (archiveCommand, settings) = ServiceProviderFixture.GetRequiredService<ICommand<ArchiveSettings>, ArchiveSettings>();
 
             // When
             var result = await archiveCommand.ExecuteAsync(
@@ -32,7 +33,7 @@ public class ArchiveCommandTests
         public async Task ExecuteAsync(string content)
         {
             // Given
-            var (archiveCommand, settings, fileSystem) = ServiceProviderFixture.GetRequiredService<ArchiveCommand, ArchiveSettings, FakeFileSystem>();
+            var (archiveCommand, settings, fileSystem) = ServiceProviderFixture.GetRequiredService<ICommand<ArchiveSettings>, ArchiveSettings, FakeFileSystem>();
             var file = fileSystem.CreateFile("/Working/InputPath/ExistingFile.json").SetContent(content);
 
             // When
@@ -60,7 +61,7 @@ public class ArchiveCommandTests
         public async Task ExecuteAsync()
         {
             // Given
-            var (archiveCommand, settings, fileSystem) = ServiceProviderFixture.GetRequiredService<ArchiveCommand, ArchiveSettings, FakeFileSystem>();
+            var (archiveCommand, settings, fileSystem) = ServiceProviderFixture.GetRequiredService<ICommand<ArchiveSettings>, ArchiveSettings, FakeFileSystem>();
             var file = fileSystem.CreateFile("/Working/InputPath/NewFile.json").SetContent("\"NewFile\"");
 
             // When

--- a/src/Blobify/Commands/ArchiveCommand.cs
+++ b/src/Blobify/Commands/ArchiveCommand.cs
@@ -12,7 +12,7 @@ public class ArchiveCommand(
         TokenService tokenService
 ) : AsyncCommand<ArchiveSettings>
 {
-    public override async Task<int> ExecuteAsync(CommandContext context, ArchiveSettings settings, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(CommandContext context, ArchiveSettings settings, CancellationToken cancellationToken)
     {
         if (settings.InputPath.IsRelative)
         {

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,11 +9,11 @@
     <PackageVersion Include="Cake.Common" Version="6.1.0" />
     <PackageVersion Include="Cake.Testing" Version="6.1.0" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-    <PackageVersion Include="Devlead.Console" Version="2026.2.11.575" />
+    <PackageVersion Include="Devlead.Console" Version="2026.5.15.709" />
     <PackageVersion Include="Devlead.Testing.MockHttp" Version="2026.5.15.777" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'"/>
     <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.16" Condition="'$(TargetFramework)' == 'net9.0'"/>
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.5" Condition="'$(TargetFramework)' == 'net10.0'"/>
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" Condition="'$(TargetFramework)' == 'net10.0'"/>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="MimeTypes" Version="2.5.2" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />


### PR DESCRIPTION
Register ArchiveCommand as ICommand<ArchiveSettings> in tests and resolve the interface in ArchiveCommandTests to match Spectre.Console.Cli DI usage.

Change ArchiveCommand.ExecuteAsync from public to protected override, required by the updated AsyncCommand base API.

Bump Devlead.Console to 2026.5.15.709 and Microsoft.Extensions.Http (net10.0) to 10.0.8 in Directory.Packages.props.